### PR TITLE
GET request url shouldn't require slash before url params

### DIFF
--- a/eve_mocker.py
+++ b/eve_mocker.py
@@ -172,7 +172,7 @@ class EveMocker(object):
             support all methods, except HEAD. """
         headers["content_type"] = "application/json"
         path = filter(lambda x: x not in ["api", ""], request.path.split('/'))
-        resource = path[0]
+        resource = path[0].split('?')[0]
         if request.method == "GET":
             _items = self.get_resource(resource)
 

--- a/eve_mocker.py
+++ b/eve_mocker.py
@@ -214,7 +214,7 @@ class EveMocker(object):
                     item["etag"] = item_etag
                     self.items[resource][pk] = item
                     out[key] = {"status": "OK", "etag": item_etag}
-            return [200, headers, json.dumps(out)]
+            return [201, headers, json.dumps(out)]
 
         elif request.method == "DELETE":
             del self.items[resource]
@@ -261,6 +261,6 @@ class EveMocker(object):
                 patch_data.update({"etag": new_etag})
                 self.items[resource][item_id].update(patch_data)
                 out[k] = {"status": "OK", "etag": new_etag}
-            return [200, headers, json.dumps(out)]
+            return [201, headers, json.dumps(out)]
 
         return [405, headers, "{}"]

--- a/eve_mocker.py
+++ b/eve_mocker.py
@@ -211,9 +211,9 @@ class EveMocker(object):
                     out[key] = {"status": "ERR", "issues": ["pk not unique"]}
                 else:
                     item_etag = generate_etag()
-                    item["etag"] = item_etag
+                    item["_etag"] = item_etag
                     self.items[resource][pk] = item
-                    out[key] = {"status": "OK", "etag": item_etag}
+                    out[key] = {"status": "OK", "_etag": item_etag}
             return [201, headers, json.dumps(out)]
 
         elif request.method == "DELETE":
@@ -236,7 +236,7 @@ class EveMocker(object):
             if not "If-Match" in request.headers:
                 return [403, headers, "{}"]
 
-            old_etag = self.items[resource][item_id]["etag"]
+            old_etag = self.items[resource][item_id]["_etag"]
 
             if request.headers["If-Match"] != old_etag:
                 return [412, headers, "{}"]
@@ -258,9 +258,9 @@ class EveMocker(object):
             for k, patch_data in qs.items():
                 patch_data = json.loads(patch_data[0])
                 new_etag = generate_etag()
-                patch_data.update({"etag": new_etag})
+                patch_data.update({"_etag": new_etag})
                 self.items[resource][item_id].update(patch_data)
-                out[k] = {"status": "OK", "etag": new_etag}
+                out[k] = {"status": "OK", "_etag": new_etag}
             return [201, headers, json.dumps(out)]
 
         return [405, headers, "{}"]

--- a/test_eve_mocker.py
+++ b/test_eve_mocker.py
@@ -42,18 +42,18 @@ class TestEveMocker(unittest.TestCase):
         data = response.json()
 
         # Check the status of the item and if it has an etag
-        expect(response.status_code).to.equal(200)
+        expect(response.status_code).to.equal(201)
         expect(data).to.have.key("mymodel1")
         expect(data["mymodel1"]["status"]).to.equal("OK")
-        expect(data["mymodel1"]).to.have.key("etag")
+        expect(data["mymodel1"]).to.have.key("_etag")
 
         # Storing the ETag for later
-        mymodel1_etag = data["mymodel1"]["etag"]
+        mymodel1_etag = data["mymodel1"]["_etag"]
 
         # Check that it has actually been created
         response = requests.get(mymodel_url)
         mymodel1_test = mymodel1.copy()
-        mymodel1_test.update({"etag": data["mymodel1"]["etag"]})
+        mymodel1_test.update({"_etag": data["mymodel1"]["_etag"]})
 
         expect(response.status_code).to.equal(200)
         expect(response.json()).to.equal({"_items": [mymodel1_test]})
@@ -71,7 +71,7 @@ class TestEveMocker(unittest.TestCase):
                                  {"mymodel1": json.dumps(mymodel1)})
         data = response.json()
 
-        expect(response.status_code).to.equal(200)
+        expect(response.status_code).to.equal(201)
         expect(data).to.have.key("mymodel1")
         expect(data["mymodel1"]["status"]).to.equal("ERR")
 
@@ -95,13 +95,13 @@ class TestEveMocker(unittest.TestCase):
                                   headers={"If-Match": mymodel1_etag})
         data = response.json()
 
-        expect(response.status_code).to.equal(200)
+        expect(response.status_code).to.equal(201)
         expect(data).to.have.key("data")
         expect(data["data"]["status"]).to.equal("OK")
-        expect(data["data"]).to.have.key("etag")
+        expect(data["data"]).to.have.key("_etag")
 
-        mymodel1_etag = data["data"]["etag"]
-        mymodel1_test.update({"etag": mymodel1_etag,
+        mymodel1_etag = data["data"]["_etag"]
+        mymodel1_test.update({"_etag": mymodel1_etag,
                               "content": "new content"})
 
         # Check if the item has been updated


### PR DESCRIPTION
A GET query with a slash before the params `'testresource/?where={"content": "content1"}'` does succeed, but the same querry without the tailing slash  `'testresource?where={"content": "content1"}'` will return no items.

I think this shouldn't be the case.

regards
Hannes 
